### PR TITLE
v28.2

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,3 +4,4 @@ set -euxo pipefail
 
 mkdir -p $PREFIX/share/bazel/protobuf
 cp -r bazel $PREFIX/share/bazel/protobuf/
+rm -rf $PREFIX/share/bazel/protobuf/tests

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 28.1
+  version: 28.2
   major: 5
 
 package:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/protocolbuffers/protobuf/releases/download/v${{ version }}/protobuf-${{ version }}.tar.gz
-  sha256: 3b8bf6e96499a744bd014c60b58f797715a758093abf859f1d902194b8e1f8c9
+  sha256: b2340aa47faf7ef10a0328190319d3f3bee1b24f426d4ce8f4253b6f27ce16db
 
 build:
   number: 0


### PR DESCRIPTION
We'll need this to match our current pinning; also, I think it should be fine to delete the tests folder from https://github.com/protocolbuffers/protobuf/tree/main/bazel